### PR TITLE
added workaround for empty result set due to fastlinks

### DIFF
--- a/src/fft.jl
+++ b/src/fft.jl
@@ -13,8 +13,17 @@ function set_oracle(index, fastlinks::Dict{UInt64,KnnResult})
                 end
             end
         end
+
+        if length(L) == 0
+            # just link randomly for orthogonal vectors
+            n = length(index.db)
+            return rand(1:n, floor(Int, log2(n+1)))
+        end
+
+        # @show L, fastlinks
         L
     end
+
     index.options.oracle = oracle
     fastlinks
 end


### PR DESCRIPTION
The problem is due to vector's orthogonality; however, in some cases, it is desirable to select some items even when they have no shared tokens (like initial FFT's steps)